### PR TITLE
Drop `fenics-dev@googlegroups.com` in favor of `fenics-steering-council@googlegroups.com`

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,8 +3,8 @@
 [metadata]
 name = fenics-ufl-legacy
 version = 2022.3.0
-author = FEniCS Project Contributors
-email = fenics-dev@googlegroups.com
+author = FEniCS Project Steering Council
+email = fenics-steering-council@googlegroups.com
 maintainer = FEniCS Project Steering Council
 description = Unified Form Language
 url = https://github.com/FEniCS/ufl

--- a/setup.cfg
+++ b/setup.cfg
@@ -3,9 +3,9 @@
 [metadata]
 name = fenics-ufl-legacy
 version = 2022.3.0
-author = FEniCS Project Steering Council
+author = FEniCS Steering Council
 email = fenics-steering-council@googlegroups.com
-maintainer = FEniCS Project Steering Council
+maintainer = FEniCS Steering Council
 description = Unified Form Language
 url = https://github.com/FEniCS/ufl
 project_urls =


### PR DESCRIPTION
In preparation of `fenics-dev@googlegroups.com` shutting down.